### PR TITLE
[Bug Fix]: Uses the canonical provided LXD installation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup LXD
-        uses: canonical/setup-lxd@90d7610
+        uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
         with:
           channel: 5.10/stable
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,15 +5,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Setup LXD
-        uses: whywaita/setup-lxd@v1
+        uses: canonical/setup-lxd@90d7610
         with:
-          lxd_version: latest/stable
+          channel: 5.10/stable
 
       - name: Install rockcraft
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
The Ubuntu Github Actions runners that use 22.04 have a conflict where the rules that ship with docker prevent LXD containers from accessing the internet by default. The last version of the rock used Ubuntu 20.04 to avoid this. Here we leverage ubuntu 22.04 and avoid the problem by using the Canonical provided `setup-lxd` action that includes setuping those rules.