### PR TITLE
update canonical/setup-lxd to v0.1.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup LXD
-        uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
+        uses: canonical/setup-lxd@v0.1.1
         with:
           channel: 5.10/stable
 


### PR DESCRIPTION
There is a bug in canonical/setup-lxd@v0.1.0 where the `channel` input is ignored. This has been fixed in v0.1.1. See https://github.com/canonical/setup-lxd/pull/8