### PR TITLE
Update LXD version to latest stable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
         with:
-          channel: 5.10/stable
+          channel: 5.16/stable
 
       - name: Install rockcraft
         run: |


### PR DESCRIPTION
5.10 stable is no longer available on the snap store.