### PR TITLE
chore: Moves ownership to TLS team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/telco
+*       @canonical/tls


### PR DESCRIPTION
## Description

Since we are separating the Telco team from a new TLS team, we now have a new Github group named tls. This PR moves this project's ownership to the TLS team.
