### PR TITLE
chore: Uses new rockcraft.yaml syntax for base

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -5,7 +5,7 @@ description: |
 version: "4.14.2"
 license: Apache-2.0
 base: bare
-build-base: ubuntu:22.04
+build-base: ubuntu@22.04
 platforms:
   amd64:
 


### PR DESCRIPTION
# Description

The way the base image is represented in rockcraft.yaml has recently changed. This PR uses the new way to specify base image.

## Reference
- https://canonical-rockcraft.readthedocs-hosted.com/en/latest/reference/rockcraft.yaml/