### PR TITLE
chore: Bumps artefact actions to v4

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rock
           path: ${{ steps.rockcraft.outputs.rock }}

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -4,7 +4,6 @@ on:
   workflow_call:
 
 jobs:
-
   publish-rock:
     runs-on: ubuntu-22.04
     steps:
@@ -21,7 +20,7 @@ jobs:
       - name: Install skopeo
         run: |
           sudo snap install --devmode --channel edge skopeo
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rock
 

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -4,7 +4,6 @@ on:
   workflow_call:
 
 jobs:
-
   scan:
     runs-on: ubuntu-22.04
     steps:
@@ -19,7 +18,7 @@ jobs:
         run: |
           sudo snap install yq
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rock
 
@@ -40,10 +39,10 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "ghcr.io/canonical/${{env.image_name}}:${{env.version}}"
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          format: "sarif"
+          output: "trivy-results.sarif"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
# Description
Bumps actions workflow to v4. This should remove the need for the following PR's which are failing because they have been pushed separately instead of combined:

- PR #32 
- PR #33 

There seems to be this intermittent issue with v4 that I experienced here. We may want to pause before merging this PR:
- https://github.com/actions/download-artifact/issues/249